### PR TITLE
(fix) Allow translations to be loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@icrc/openmrs-esm-patient-grid-app",
+  "name": "@icrc/esm-patient-grid-app",
   "version": "1.0.1",
   "license": "BSD-3-Clause",
   "description": "The microfrontend module providing the patient grid feature.",

--- a/src/api/patientGridReport.ts
+++ b/src/api/patientGridReport.ts
@@ -6,18 +6,18 @@ import { useMutation } from './useMutation';
 export interface PatientGridReportGet {
   patientGrid: OpenmrsResource;
   report: Array<PatientGridReportRowGet>;
-  reportMetadata : PatientGridReportMetaData;
+  reportMetadata: PatientGridReportMetaData;
 }
 
 export interface PatientGridReportRowGet
   extends Record<string, undefined | null | string | number | boolean | PatientGridReportObsGet> {
   uuid: string;
 }
-export interface PatientGridReportMetaData{
+export interface PatientGridReportMetaData {
   truncated: string;
   rowsCountLimit: number;
   initialRowsCount: number;
-  periodOperand:{
+  periodOperand: {
     fromDate: string;
     toDate: string;
     code: string;

--- a/src/patient-grid-details/PatientGridDetailsHeader.tsx
+++ b/src/patient-grid-details/PatientGridDetailsHeader.tsx
@@ -41,7 +41,6 @@ export function PatientGridDetailsHeader({
   };
 
   return (
-    
     <PageHeader
       title={
         <h1 className={styles.title}>
@@ -55,10 +54,16 @@ export function PatientGridDetailsHeader({
       subTitle={
         patientGridReport ? (
           <div>
-          <span className={styles.subTitle}>{patientGridReport.report.length} patients   </span>
-          <span >{patientGridReport.reportMetadata.truncated && 
-            <span className={styles.truncateText}>           Your response has been truncated to {patientGridReport.reportMetadata.rowsCountLimit} records. The actual response has {patientGridReport.reportMetadata.initialRowsCount} records.</span>
-          }</span>
+            <span className={styles.subTitle}>{patientGridReport.report.length} patients </span>
+            <span>
+              {patientGridReport.reportMetadata.truncated && (
+                <span className={styles.truncateText}>
+                  {' '}
+                  Your response has been truncated to {patientGridReport.reportMetadata.rowsCountLimit} records. The
+                  actual response has {patientGridReport.reportMetadata.initialRowsCount} records.
+                </span>
+              )}
+            </span>
           </div>
         ) : (
           <SkeletonText width="30%" />

--- a/src/patient-grids-overview/PatientGridBuilderFiltersPage.tsx
+++ b/src/patient-grids-overview/PatientGridBuilderFiltersPage.tsx
@@ -33,7 +33,7 @@ export function PatientGridBuilderFiltersPage({ page, pages, goToPrevious, state
   const genders = useAllGenders();
   const periods = useAllPeriods();
   const { data: ageRanges } = useGetAllAgeRanges();
-  
+
   const setLastPeriodFilter = (value: string) => {
     const periodFilter: PatientGridFilterPost = {
       name: '',
@@ -188,7 +188,7 @@ export function PatientGridBuilderFiltersPage({ page, pages, goToPrevious, state
           setState((state) => ({
             ...state,
             periodFilterType: e.target.value ? e.target.value : undefined,
-            periodFilter:null
+            periodFilter: null,
           }))
         }>
         {periods.map(({ period, display }) => (
@@ -212,7 +212,7 @@ export function PatientGridBuilderFiltersPage({ page, pages, goToPrevious, state
           <RadioButton id="today" labelText={t('filterToday', 'Today')} value="today" />
           <RadioButton id="yesterday" labelText={t('filterYesterday', 'Yesterday')} value="yesterday" />
           <RadioButton id="lastSevenDays" labelText={t('filterLastSevenDays', 'Last 7 days')} value="lastSevenDays" />
-          <RadioButton 
+          <RadioButton
             id="lastThirtyDays"
             labelText={t('filterLastThirtyDays', 'Last 30 days')}
             value="lastThirtyDays"

--- a/src/patient-grids-overview/usePatientGridWizard.tsx
+++ b/src/patient-grids-overview/usePatientGridWizard.tsx
@@ -83,7 +83,9 @@ export function usePatientGridWizard(formSchemas: Record<string, FormSchema>) {
   );
 
   const isStateValidForSubmission = useMemo(() => {
-    return state.name?.trim().length && state.selectedForms.length && state.countryFilter?.name && state.periodFilter?.name;
+    return (
+      state.name?.trim().length && state.selectedForms.length && state.countryFilter?.name && state.periodFilter?.name
+    );
   }, [state]);
 
   const createPostBody = useCallback(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,9 +1884,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@icrc/openmrs-esm-patient-grid-app@workspace:.":
+"@icrc/esm-patient-grid-app@workspace:.":
   version: 0.0.0-use.local
-  resolution: "@icrc/openmrs-esm-patient-grid-app@workspace:."
+  resolution: "@icrc/esm-patient-grid-app@workspace:."
   dependencies:
     "@carbon/react": ^1.9.0
     "@openmrs/esm-framework": next


### PR DESCRIPTION
@icrc-fdeniger This should fix translations for this app. The issue was that the app name used internally (@icrc/esm-patient-grid-app) didn't match the app name of the package itself (@icrc/openmrs-esm-patient-grid-app) which means that at runtime, translations were never loaded in this app.