### PR TITLE
(bugfix) - Use display property on columns header and support multiselect values

### DIFF
--- a/src/patient-grid-details/PatientGridDetailsPage.tsx
+++ b/src/patient-grid-details/PatientGridDetailsPage.tsx
@@ -1,5 +1,5 @@
 import { ErrorState, ExtensionSlot, showToast, useSession } from '@openmrs/esm-framework';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import { Hr, PageWithSidePanel, PageWithSidePanelProps } from '../components';
 import { PatientGridDetailsHeader } from './PatientGridDetailsHeader';
 import { Stack } from '@carbon/react';
@@ -55,7 +55,29 @@ export function PatientGridDetailsPage() {
     setSidePanelSize('lg');
   };
 
+  const getDisplayProperty = useCallback(
+    (name: string) => {
+      const column = patientGrid?.columns.find((column) => column.name === name);
+      return column ? column.display : name;
+    },
+    [patientGrid?.columns],
+  );
+
+  const extractHeadersFromPatientGrid = useCallback(
+    (columns) => {
+      columns.forEach((obj) => {
+        if (!obj.columns) {
+          obj.header = getDisplayProperty(obj.header);
+        } else {
+          extractHeadersFromPatientGrid(obj.columns);
+        }
+      });
+    },
+    [getDisplayProperty],
+  );
+
   const showToggleColumnsSidePanel = () => {
+    extractHeadersFromPatientGrid(data.columns);
     setSidePanel(<ToggleColumnsSidePanel columns={data.columns} onClose={() => setSidePanel(undefined)} />);
     setSidePanelSize('md');
   };

--- a/src/patient-grid-details/useHistoricEncountersGrid.ts
+++ b/src/patient-grid-details/useHistoricEncountersGrid.ts
@@ -55,7 +55,7 @@ function createDataFromHistoricEncounters(
 
     for (const { question } of relevantQuestions) {
       const conceptUuid = question.questionOptions.concept;
-      const matchingObs = conceptUuid ? encounter.obs.find((obs) => obs.concept.uuid === conceptUuid) : undefined;
+      const matchingObs = conceptUuid ? encounter.obs.filter((obs) => obs.concept.uuid === conceptUuid) : undefined;
       if (matchingObs) {
         encounterRow[getFormSchemaQuestionColumnName(form, question)] = obsToDisplayString(matchingObs);
       }
@@ -67,13 +67,10 @@ function createDataFromHistoricEncounters(
   return result;
 }
 
-function obsToDisplayString(obs: PastEncounterObsGet) {
-  // TODO: This is probably not exhaustive yet. Other things an obs could be here?
-  if (obs.value === null || obs.value === undefined) {
-    return '';
-  } else if (typeof obs.value === 'object') {
-    return obs.value.display ?? ''; // TODO: Is this localized? Should it be?
-  } else {
-    return `${obs.value}`;
-  }
+function obsToDisplayString(obs: PastEncounterObsGet[]) {
+  const valuesArray = obs.map((obs) => obs.value);
+  return valuesArray
+    .filter((value) => value !== null && value !== undefined)
+    .map((value) => (typeof value === 'object' ? value.display ?? '' : `${value}`))
+    .join(', ');
 }


### PR DESCRIPTION
This Pull request updates the columns header in the project. The main changes are:

1. Using the display property to enhance the styling of the columns header.
2. Adding support for multi-select values, which allows users to see the obs filled by a multi-select field on patientGrid .

Thanks
CC: @icrc-fdeniger 