### PR TITLE
(feat) Allow specifying hidden columns by configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,24 @@ Also, possible to use a docker container to run yarn:
 sh run.sh yarn  # to install dependencies
 sh run.sh yarn start  # to run the dev server
 ```
+
+## Configuration
+### Default hidden columns
+It's possible to specify which questions will result in hidden columns by default when creating a new grid. Users can then enable hidden columns after the grid is created if needed.
+
+To specify the default hidden columns, one must utilize the config-schema by providing the form UUID along with its corresponding question IDs.
+
+Below, here's an example to hide the columns for "nhif" and "nhifStatus" questions for the form [adult-1.4.json](https://github.com/openmrs/openmrs-ngx-formentry/blob/main/src/app/adult-1.4.json):
+
+```json
+{
+  "@icrc/esm-patient-grid-app": {
+    "gridFormConfig": [
+      {
+        "formUuid": "bcb914ea-1e03-4c7f-9fd5-1baba5841e78",
+        "defaultHiddenQuestionIds": ["nhif", "nhifStatus"]
+      }
+    ]
+  }
+}
+```

--- a/src/config-schema.ts
+++ b/src/config-schema.ts
@@ -6,8 +6,27 @@ export const configSchema = {
     _description: 'The UUID to be used for age ranges in patient grids.',
     _default: undefined,
   },
+  gridFormConfig: {
+    _type: Type.Array,
+    _description: 'List of forms for this category.',
+    _elements: {
+      formUuid: {
+        _type: Type.UUID,
+        _description: 'UUID of form',
+      },
+      defaultHiddenQuestionIds: {
+        _type: Type.Array,
+      },
+    },
+  },
 };
 
 export type Config = Record<string, unknown> & {
   ageRangeEncounterTypeUuid?: string;
+  gridFormConfig?: Array<GridFormConfig>;
 };
+
+export interface GridFormConfig {
+  formUuid: string;
+  defaultHiddenQuestionIds: string;
+}

--- a/src/patient-grids-overview/usePatientGridWizard.tsx
+++ b/src/patient-grids-overview/usePatientGridWizard.tsx
@@ -113,12 +113,13 @@ export function usePatientGridWizard(formSchemas: Record<string, FormSchema>) {
           state.selectedForms,
           formSchemas,
           state.periodFilter ? [state.periodFilter] : undefined,
+          config.gridFormConfig,
         ),
       ],
     };
 
     return body;
-  }, [state, formSchemas, config.ageRangeEncounterTypeUuid, session.user]);
+  }, [state, formSchemas, config.ageRangeEncounterTypeUuid, config.gridFormConfig, session.user]);
 
   return {
     currentPage,


### PR DESCRIPTION
This development allows to specify the columns per form that will be hidden by default when creating a new grid. Users can then enable them if needed. Prior to this development all columns would be enabled and shown by default.

## Configuration
To specify the default hidden columns, one must utilize the config-schema by providing the form UUID along with its corresponding question IDs.

Below, here's an example to hide the columns for "nhif" and "nhifStatus" questions for the form [adult-1.4.json](https://github.com/openmrs/openmrs-ngx-formentry/blob/main/src/app/adult-1.4.json):

```json
{
  "@icrc/esm-patient-grid-app": {
    "gridFormConfig": [
      {
        "formUuid": "bcb914ea-1e03-4c7f-9fd5-1baba5841e78",
        "defaultHiddenQuestionIds": ["nhif", "nhifStatus"]
      }
    ]
  }
}