### PR TITLE
Frontend issue while opening several Patient Grids

### DIFF
--- a/src/grid-utils/localRowFiltering.ts
+++ b/src/grid-utils/localRowFiltering.ts
@@ -2,7 +2,7 @@ import { PatientGridReportRowGet } from '../api';
 import { LocalFilter } from './useInlinePatientGridEditing';
 
 export function getLocallyFilteredReportRows(rows: Array<PatientGridReportRowGet>, filters: Array<LocalFilter>) {
-  const localFilters = filters.filter((filter) => !('uuid' in filter));
+  const localFilters = filters?.filter((filter) => !('uuid' in filter)) || [];
 
   if (!localFilters.length) {
     return rows;

--- a/src/patient-grid-details/PatientGridDetailsPage.tsx
+++ b/src/patient-grid-details/PatientGridDetailsPage.tsx
@@ -116,7 +116,7 @@ export function PatientGridDetailsPage() {
     return <PatientGridReportLoadingIndicator />;
   }
 
-  return (
+  return patientGrid ? (
     <InlinePatientGridEditingContext.Provider value={inlinePatientGridEditingState}>
       <PageWithSidePanel sidePanel={sidePanel} showSidePanel={!!sidePanel} sidePanelSize={sidePanelSize}>
         <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
@@ -166,5 +166,5 @@ export function PatientGridDetailsPage() {
         />
       </PageWithSidePanel>
     </InlinePatientGridEditingContext.Provider>
-  );
+  ) : null;
 }


### PR DESCRIPTION
## Pull Request Description

### Changes Made
- Added null safe clauses to prevent runtime operations based on undefined variables.
- Addressed an issue where certain parts of the patient grid page were rendered without complete information during the loading process.
- Improved visibility of the issue, particularly when switching between grids using breadcrumbs.

### Problem Statement
During the loading of the patient grid page, certain components were rendered without all the required information. This issue occurred because the necessary data was being fetched from the backend asynchronously. Consequently, attempting to perform operations based on undefined variables resulted in runtime errors.
This problem was more visible when i switched between grids using breadcrumbs.

### Solution Implemented
To solve the problem, I introduced null safe clauses to the codebase. By checking for null values before executing operations, I ensured that any undefined variables or incomplete data would not cause runtime errors.

CC: @icrc-fdeniger 


