### PR TITLE
(feat) Allow editing encounters on historic encounters listing

### DIFF
--- a/src/patient-grid-details/HistoricEncountersGrid.scss
+++ b/src/patient-grid-details/HistoricEncountersGrid.scss
@@ -8,3 +8,7 @@ table.table {
   display: flex;
   align-items: center;
 }
+
+.clickableCell {
+  cursor: pointer;
+}

--- a/src/patient-grid-details/HistoricEncountersTabs.tsx
+++ b/src/patient-grid-details/HistoricEncountersTabs.tsx
@@ -12,14 +12,21 @@ import {
 import { getFormsReferencedInGridReport, getFormSchemaReferenceUuid } from '../grid-utils';
 import { useTranslation } from 'react-i18next';
 import { HistoricEncountersGrid } from './HistoricEncountersGrid';
+import { EditSidePanelValues } from './PatientGridDetailsPage';
 
 export interface HistoricEncountersTabsProps {
   report: PatientGridReportGet;
   reportRow: PatientGridReportRowGet;
   patientGrid: PatientGridGet;
+  showEditSidePanel(values: EditSidePanelValues): void;
 }
 
-export function HistoricEncountersTabs({ report, reportRow, patientGrid }: HistoricEncountersTabsProps) {
+export function HistoricEncountersTabs({
+  report,
+  reportRow,
+  patientGrid,
+  showEditSidePanel,
+}: HistoricEncountersTabsProps) {
   const { t } = useTranslation();
   const formsSwr = useGetAllPrivilegeFilteredForms();
   const formSchemasSwr = useFormSchemasOfForms(formsSwr.data);
@@ -51,6 +58,7 @@ export function HistoricEncountersTabs({ report, reportRow, patientGrid }: Histo
                   patientId={reportRow.uuid}
                   report={report}
                   patientGrid={patientGrid}
+                  showEditSidePanel={showEditSidePanel}
                 />
               </TabPanel>
             ))}

--- a/src/patient-grid-details/PatientGrid.tsx
+++ b/src/patient-grid-details/PatientGrid.tsx
@@ -331,6 +331,7 @@ export function PatientGrid({
                               report={row.original.__report}
                               reportRow={row.original.__reportRow}
                               patientGrid={patientGrid}
+                              showEditSidePanel={showEditSidePanel}
                             />
                           </div>
                         </TableExpandedRow>

--- a/src/patient-grid-details/useHistoricEncountersGrid.ts
+++ b/src/patient-grid-details/useHistoricEncountersGrid.ts
@@ -61,6 +61,8 @@ function createDataFromHistoricEncounters(
       }
     }
 
+    encounterRow.encounterUuid = encounter.uuid;
+
     result.push(encounterRow);
   }
 


### PR DESCRIPTION
Similar to the behavior on the main grid, with this development, when clicking a cell in one of the rows of the historic encounters grid, the respective encounter will open on the left panel allowing the user to edit it.

![image](https://github.com/icrc/openmrs-esm-patient-grid-app/assets/68599335/f53a35b5-eb39-4fa3-bb4c-e49d694fef19)
