### PR TITLE
(fix) Disallow multiple filters per column

### DIFF
--- a/src/patient-grid-details/PatientGridColumnFiltersButton.tsx
+++ b/src/patient-grid-details/PatientGridColumnFiltersButton.tsx
@@ -60,7 +60,13 @@ function FiltersPopoverContent({ patientGridId, column, columnDisplayName, close
 
   const handleFilterClick = (filter: LocalFilter, checked: boolean) => {
     if (checked) {
-      setLocalFilters([...localFilters, filter]);
+      setLocalFilters([
+        // Only allow one filter per column. Having multiple filters for the same column will require a review on the filtering mechanism.
+        ...localFilters.filter(function (localFilter) {
+          return localFilter.columnName !== filter.columnName;
+        }),
+        filter,
+      ]);
     } else {
       setLocalFilters(localFilters.filter((x) => x.columnName !== filter.columnName && x.operand !== filter.operand));
     }


### PR DESCRIPTION
Currently, it's only possible to filter by a single value per column. Selecting multiple values on the filter for the same column would cause the table to be empty. To avoid this, at least until the filtering mechanism is working properly with multiple values, the user will be only allowed to select a single value from the filter dropdown.
![image](https://github.com/icrc/openmrs-esm-patient-grid-app/assets/68599335/978ec37b-30df-4c90-995d-8a25597da6f0)
