### PR TITLE
(fix) Allow backend date filters

### DIFF
--- a/src/grid-utils/useInlinePatientGridEditing.ts
+++ b/src/grid-utils/useInlinePatientGridEditing.ts
@@ -9,7 +9,7 @@ import {
 } from '../api';
 import { ColumnNameToHiddenStateMap, useColumnHiddenStates } from '.';
 import { UndoRedo, useUndoRedo } from './useUndoRedo';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { formatDate, openmrsFetch } from '@openmrs/esm-framework';
 
 export interface LocalFilter {
   uuid?: string;
@@ -48,6 +48,10 @@ export interface InlinePatientGridEditingContextState extends UndoRedo<InlinePat
 
 export const InlinePatientGridEditingContext = createContext<InlinePatientGridEditingContextState>(null);
 
+function isValidDate(date) {
+  return date instanceof Date && !isNaN(date.getTime());
+}
+
 export function useInlinePatientGridEditingContextState(patientGridId: string): InlinePatientGridEditingContextState {
   const originalColumnHiddenStatesSwr = useColumnHiddenStates(patientGridId);
   const originalFiltersSwr = useGetAllPatientGridFilters(patientGridId);
@@ -60,7 +64,11 @@ export function useInlinePatientGridEditingContextState(patientGridId: string): 
         uuid: filter.uuid,
         name: filter.name,
         operand: filter.operand,
-        display: filter.display,
+        display: isValidDate(new Date(filter.display))
+          ? formatDate(new Date(filter.display), {
+              time: true,
+            })
+          : filter.display,
         // In the filter representation, "display" holds the column name.
         // May be brittle. Should perhaps be improved eventually.
         columnName: filter.column.display,

--- a/src/patient-grid-details/PatientGridFiltersHeader.tsx
+++ b/src/patient-grid-details/PatientGridFiltersHeader.tsx
@@ -86,7 +86,7 @@ function FilterTag({ filter, saveChanges }: FilterTagProps) {
   const handleDelete = async () => {
     await push((state) => ({
       ...state,
-      filters: filters.filter((x) => x.columnName !== filter.columnName && x.operand !== filter.operand),
+      filters: filters.filter((x) => x.columnName !== filter.columnName || x.operand !== filter.operand),
     }));
     push((state) => ({
       ...state,


### PR DESCRIPTION
- Format dates on filters retrieved from backend according to user locale so that they can properly be applied.
- Fixed issue when removing a filter causing wrong filters to be removed just because either column name or operand are equal. Both must me equal in order to match the removed filter by the user.