### PR TITLE
(fix) Excel download for patient grids

### DIFF
--- a/src/patient-grid-details/DownloadModal.tsx
+++ b/src/patient-grid-details/DownloadModal.tsx
@@ -39,6 +39,7 @@ export function DownloadModal({ patientGridId, isOpen, onClose, refreshGrid }: D
     const wb = xlsx.utils.book_new();
     xlsx.utils.book_append_sheet(wb, sheet, patientGrid.name);
     xlsx.writeFile(wb, fileName);
+    await saveHandler();
     onClose();
   };
   const saveHandler = async () => {
@@ -117,7 +118,6 @@ export function DownloadModal({ patientGridId, isOpen, onClose, refreshGrid }: D
         : t('downloadModalChooseDownloadPrimaryButtonTextConvert', 'Convert & Download'),
       secondaryButtonText: t('downloadModalChooseDownloadSecondaryButtonTextCancel', 'Cancel'),
       onRequestSubmit() {
-        saveHandler();
         setHasDownloadStarted(true);
       },
       onSecondarySubmit() {


### PR DESCRIPTION
. Changed placement of saveHandler to execute after the download is complete, only afterward the reload of the gird will be done.

. Added an awaiting so the popup only disappears after the save/reload is triggered.