### PR TITLE
(fix) Make sure that downloaded grid file has up-to-date records

### DIFF
--- a/src/patient-grid-details/DownloadModal.tsx
+++ b/src/patient-grid-details/DownloadModal.tsx
@@ -160,15 +160,15 @@ interface PrepareDownloadProps {
 
 function PrepareDownload({ patientGridId, onDownloadPrepared }: PrepareDownloadProps) {
   const { t } = useTranslation();
-  const { data, error } = useDownloadGridData(patientGridId);
+  const { data, error, isValidating } = useDownloadGridData(patientGridId);
   const triggered = useRef(false);
 
   useEffect(() => {
-    if (data && !triggered.current) {
+    if (data && !triggered.current && !isValidating) {
       triggered.current = true;
       onDownloadPrepared(data);
     }
-  }, [data, error, onDownloadPrepared]);
+  }, [data, error, isValidating, onDownloadPrepared]);
 
   return (
     <p>


### PR DESCRIPTION
Make sure that downloaded grid file has up-to-date records considering all the active filters as displayed to the user.

![image](https://github.com/icrc/openmrs-esm-patient-grid-app/assets/68599335/f9292487-aaa0-40d7-8e77-af61da29e8ec)
