### PR TITLE
(fix) Cope with unlabeled sections when processing form columns

### DIFF
--- a/src/grid-utils/gridColumns.ts
+++ b/src/grid-utils/gridColumns.ts
@@ -66,7 +66,7 @@ export function getReactTableColumnDefForForm(
   for (const page of formSchema.pages ?? []) {
     for (const section of page.sections ?? []) {
       const sectionColumn: GroupColumnDef<Record<string, string>> = {
-        header: section.label,
+        header: section.label || page.label,
         columns: [],
       };
 


### PR DESCRIPTION
Ensure proper handling of unlabeled sections in grid header creation. This fix utilizes the parent page label to avoid issues with undefined label columns in the table renderer, preventing potential errors.